### PR TITLE
Reject invalid bools when parsing

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -54,7 +54,11 @@ class boolean(int, BasicView):
 
     @classmethod
     def decode_bytes(cls: Type[BoolV], bytez: bytes) -> BoolV:
-        return cls(bytez != b"\x00")
+        if bytez == b"\x00":
+            return cls(0)
+        if bytez == b"\x01":
+            return cls(1)
+        raise ValueError(f"invalid bool '0x{bytez.hex()}'")
 
     @classmethod
     def from_obj(cls: Type[BoolV], obj: ObjType) -> BoolV:

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -367,6 +367,18 @@ def test_bytesn_subclass():
     assert len(Bytes32() + Bytes48()) == 80
 
 
+def test_boolean():
+    assert boolean.decode_bytes(b"\x00") == boolean(0)
+    assert boolean.decode_bytes(b"\x01") == boolean(1)
+
+    for v in (b"", b"\x02", b"\x10", b"\x80", b"\xff", b"\x00\x00"):
+        try:
+            _ = boolean.decode_bytes(v)
+            assert False
+        except ValueError:
+            pass
+
+
 def test_uint_math():
     assert uint8(0) + uint8(uint32(16)) == uint8(16)  # allow explicit casting to make invalid addition valid
 


### PR DESCRIPTION
SSZ spec defines `bool` to serialize as `0x01` or `0x00`:

- https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#boolean

and defines deserialization of basic objects as `easy`:

- https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#deserialization

In the tests it is checked that values other than `0x01` / `0x00` are rejected, though:

- https://github.com/ethereum/consensus-specs/blob/master/tests/generators/runners/ssz_generic_cases/ssz_boolean.py

Remerkleable currently does not pass the test suite, as it accepts values beyond `0x01` / `0x00` and treats them as `0x01`. Fix this.