### PR TITLE
Reject invalid uints when parsing

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -203,6 +203,8 @@ class uint(int, BasicView):
 
     @classmethod
     def decode_bytes(cls: Type[T], bytez: bytes) -> T:
+        if len(bytez) != cls.type_byte_length():
+            raise ValueError(f"invalid {cls.type_repr()} '0x{bytez.hex()}'")
         return cls(int.from_bytes(bytez, byteorder=ENDIANNESS))
 
     def encode_bytes(self) -> bytes:
@@ -214,7 +216,7 @@ class uint(int, BasicView):
             raise ObjParseException(f"obj '{obj}' is not an int or str")
         if isinstance(obj, str):
             if obj.startswith('0x'):
-                return cls.decode_bytes(bytes.fromhex(obj[2:]))
+                return cls.decode_bytes(bytes.fromhex(obj[2:]).ljust(cls.type_byte_length(), b"\x00"))
             obj = int(obj)
         return cls(obj)
 

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -379,6 +379,21 @@ def test_boolean():
             pass
 
 
+@pytest.mark.parametrize("typ", [uint8, uint16, uint32, uint64, uint128, uint256, byte])  # type: ignore
+def test_uint(typ: Type[View]):
+    rng = Random(123)
+    for i in range(0, 75):
+        bytez = bytes(rng.getrandbits(8) for _ in range(i))
+        if i == typ.type_byte_length():
+            assert typ.decode_bytes(bytez).encode_bytes() == bytez
+        else:
+            try:
+                _ = typ.decode_bytes(bytez)
+                assert False
+            except ValueError:
+                pass
+
+
 def test_uint_math():
     assert uint8(0) + uint8(uint32(16)) == uint8(16)  # allow explicit casting to make invalid addition valid
 


### PR DESCRIPTION
uints with invalid length were not properly rejected when parsing.