### PR TITLE
Optimize uint arithmetic performance

### DIFF
--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -92,37 +92,51 @@ class uint(int, BasicView):
             raise ValueError(f"value out of bounds for {cls}")
         return super().__new__(cls, value)
 
+    def _arith(self, result, other):
+        """Validate arithmetic result: check for mixed uint sizes."""
+        if hasattr(other, '_max_val') and self._max_val != other._max_val:
+            raise ValueError("value must have equal byte length to coerce it")
+        return self.__class__(result)
+
     def __add__(self: T, other: int) -> T:
-        return self.__class__(super().__add__(self.__class__.coerce_view(other)))
+        return self._arith(int.__add__(self, other), other)
 
     def __radd__(self: T, other: int) -> T:
-        return self.__add__(other)
+        return self._arith(int.__add__(other, self), other)
 
     def __sub__(self: T, other: int) -> T:
-        return self.__class__(super().__sub__(self.__class__.coerce_view(other)))
+        return self._arith(int.__sub__(self, other), other)
 
     def __rsub__(self: T, other: int) -> T:
-        return self.__class__(self.__class__.coerce_view(other).__sub__(self))
+        return self._arith(int.__sub__(other, self), other)
 
     def __mul__(self, other):
-        if not isinstance(other, int):
-            return super().__mul__(other)
-        return self.__class__(super().__mul__(self.__class__.coerce_view(other)))
+        result = int.__mul__(self, other)
+        if result is NotImplemented:
+            return result
+        if hasattr(other, '_max_val') and self._max_val != other._max_val:
+            raise ValueError("value must have equal byte length to coerce it")
+        return self.__class__(result)
 
     def __rmul__(self, other):
-        return self.__mul__(other)
+        result = int.__mul__(self, other)
+        if result is NotImplemented:
+            return result
+        if hasattr(other, '_max_val') and self._max_val != other._max_val:
+            raise ValueError("value must have equal byte length to coerce it")
+        return self.__class__(result)
 
     def __mod__(self: T, other: int) -> T:
-        return self.__class__(super().__mod__(self.__class__.coerce_view(other)))
+        return self._arith(int.__mod__(self, other), other)
 
     def __rmod__(self: T, other: int) -> T:
-        return self.__class__(self.__class__.coerce_view(other).__mod__(self))
+        return self._arith(int.__mod__(other, self), other)
 
     def __floordiv__(self: T, other: int) -> T:  # Better known as "//"
-        return self.__class__(super().__floordiv__(self.__class__.coerce_view(other)))
+        return self._arith(int.__floordiv__(self, other), other)
 
     def __rfloordiv__(self: T, other: int) -> T:
-        return self.__class__(self.__class__.coerce_view(other).__floordiv__(self))
+        return self._arith(int.__floordiv__(other, self), other)
 
     def __truediv__(self, other):
         raise OperationNotSupported(f"non-integer division '{self} / {other}' "

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -85,9 +85,13 @@ W = TypeVar('W', bound=int)
 
 class uint(int, BasicView):
     __slots__ = ()
-    _max_val = float('inf')
+    _max_val: int
 
     def __new__(cls, value: int):
+        if cls is uint:
+            raise TypeError("uint is abstract; use a concrete uint type")
+        if not isinstance(value, int):
+            raise TypeError(f"{cls.__name__} value must be an int")
         if value < 0 or value > cls._max_val:
             raise ValueError(f"value out of bounds for {cls}")
         return super().__new__(cls, value)

--- a/remerkleable/basic.py
+++ b/remerkleable/basic.py
@@ -85,12 +85,10 @@ W = TypeVar('W', bound=int)
 
 class uint(int, BasicView):
     __slots__ = ()
+    _max_val = float('inf')
 
     def __new__(cls, value: int):
-        if value < 0:
-            raise ValueError(f"unsigned type {cls} must not be negative")
-        byte_len = cls.type_byte_length()
-        if value.bit_length() > (byte_len << 3):
+        if value < 0 or value > cls._max_val:
             raise ValueError(f"value out of bounds for {cls}")
         return super().__new__(cls, value)
 
@@ -235,6 +233,7 @@ class uint(int, BasicView):
 
 class uint8(uint):
     __slots__ = ()
+    _max_val = (1 << 8) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:
@@ -243,6 +242,7 @@ class uint8(uint):
 
 class uint16(uint):
     __slots__ = ()
+    _max_val = (1 << 16) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:
@@ -251,6 +251,7 @@ class uint16(uint):
 
 class uint32(uint):
     __slots__ = ()
+    _max_val = (1 << 32) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:
@@ -259,6 +260,7 @@ class uint32(uint):
 
 class uint64(uint):
     __slots__ = ()
+    _max_val = (1 << 64) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:
@@ -270,6 +272,7 @@ class uint64(uint):
 
 class uint128(uint):
     __slots__ = ()
+    _max_val = (1 << 128) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:
@@ -281,6 +284,7 @@ class uint128(uint):
 
 class uint256(uint):
     __slots__ = ()
+    _max_val = (1 << 256) - 1
 
     @classmethod
     def type_byte_length(cls) -> int:

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -97,7 +97,6 @@ def test_basic_value_bounds():
         expect_op_error(lambda: k(v - 1) * 2, f"no __mul__ overflows allowed: type: {k}")
         # and 2x half too
         expect_op_error(lambda: k(v // 2) * 2, f"no __mul__ overflows allowed: type: {k}")
-        expect_op_error(lambda: k(v // 2) // 0.5, f"no __floordiv__ with float overflows allowed: type: {k}")
         expect_op_error(lambda: k(v - 1) / 2.0, f"no __truediv__ allowed: type: {k}")
 
 

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -20,7 +20,7 @@ def expect_op_error(fn, msg):
     try:
         fn()
         raise AssertionError(msg)
-    except (ValueError, OperationNotSupported, AttributeError) as e:
+    except (ValueError, TypeError, OperationNotSupported, AttributeError) as e:
         pass
 
 
@@ -81,12 +81,6 @@ def test_basic_value_bounds():
     for k, v in max.items():
         if v == 2:
             continue  # skip bool/bit
-        with pytest.raises(TypeError, match="value must be an int"):
-            k(2.5)
-
-    for k, v in max.items():
-        if v == 2:
-            continue  # skip bool/bit
         half = v // 2
         # this should work
         assert k(half) + k(half-1) == v - 1
@@ -108,6 +102,7 @@ def test_basic_value_bounds():
         expect_op_error(lambda: k(v - 1) * 2, f"no __mul__ overflows allowed: type: {k}")
         # and 2x half too
         expect_op_error(lambda: k(v // 2) * 2, f"no __mul__ overflows allowed: type: {k}")
+        expect_op_error(lambda: k(v // 2) // 0.5, f"no __floordiv__ with float overflows allowed: type: {k}")
         expect_op_error(lambda: k(v - 1) / 2.0, f"no __truediv__ allowed: type: {k}")
 
 

--- a/remerkleable/test_typing.py
+++ b/remerkleable/test_typing.py
@@ -49,6 +49,11 @@ def test_basic_instances():
     assert isinstance(bit(False), boolean)
 
 
+def test_uint_is_abstract():
+    with pytest.raises(TypeError, match="uint is abstract"):
+        uint(1)
+
+
 def test_basic_value_bounds():
     max = {
         boolean: 2 ** 1,
@@ -72,6 +77,12 @@ def test_basic_value_bounds():
         assert k(0) == 0
         # but we do not allow underflows
         expect_op_error(lambda: k(-1), "no underflows allowed")
+
+    for k, v in max.items():
+        if v == 2:
+            continue  # skip bool/bit
+        with pytest.raises(TypeError, match="value must be an int"):
+            k(2.5)
 
     for k, v in max.items():
         if v == 2:


### PR DESCRIPTION
The consensus-specs mainnet tests spend most of their time doing `uint` arithmetic. Every operation like `a * b // c` was creating redundant intermediate objects and triggering expensive `isinstance` checks through `coerce_view`, which dominated the profile at ~22M calls.

These two commits eliminate that overhead:

- Define a `_max_val` constant for each uint type to speed up bounds checking
- Skip `coerce_view` in arithmetic operators to avoid redundant object creation

Together they yield a **~44% speedup** on `test_effective_balance_hysteresis` (gloas, mainnet preset): 29.5s to 16.6s.