### PR TITLE
Reject non-canonical container offsets

### DIFF
--- a/remerkleable/complex.py
+++ b/remerkleable/complex.py
@@ -945,9 +945,9 @@ class Container(_ContainerBase):
                     dyn_fields.append(FieldOffset(key=fkey, typ=ftyp, offset=int(decode_offset(stream))))
                     fixed_size += OFFSET_BYTE_LENGTH
             if len(dyn_fields) > 0:
-                if dyn_fields[0].offset < fixed_size:
+                if dyn_fields[0].offset != fixed_size:
                     raise Exception(f"first offset {dyn_fields[0].offset} is "
-                                    f"smaller than expected fixed size {fixed_size}")
+                                    f"not equal to expected fixed size {fixed_size}")
                 for i, (fkey, ftyp, foffset) in enumerate(dyn_fields):
                     next_offset = dyn_fields[i + 1].offset if i + 1 < len(dyn_fields) else scope
                     if foffset > next_offset:

--- a/remerkleable/test_impl.py
+++ b/remerkleable/test_impl.py
@@ -1190,6 +1190,19 @@ def test_container_invalid():
         _ = SmallTestStruct.decode_bytes(bytes.fromhex("a7e1d33b00"))
 
 
+def test_container_rejects_first_offset_past_fixed_section():
+    class Example(Container):
+        fixed: uint8
+        items: List[uint8, 4]
+
+    value = Example(fixed=9, items=[1, 2])
+    assert value.encode_bytes().hex() == "09050000000102"
+
+    malformed = bytes.fromhex("09060000000102")
+    with pytest.raises(Exception, match="first offset 6 is not equal to expected fixed size 5"):
+        Example.decode_bytes(malformed)
+
+
 @pytest.mark.parametrize("base_typs", [
     (Container, Container),
     (ProgressiveContainer(active_fields=[1, 1, 1]), ProgressiveContainer(active_fields=[1, 1, 1, 1])),


### PR DESCRIPTION
## Summary

Require a container’s first variable-field offset to exactly match the size of its fixed section.

Previously, deserialization only rejected offsets smaller than the fixed section. An offset pointing past it could therefore skip bytes, causing malformed input to be accepted and decoded differently from its declared layout.

Found by Codex while [toying around with SSZ](https://github.com/eth2353/spy-ssz).

## Changes

- Reject first offsets that do not equal the fixed-section size.
- Add a regression test covering an offset that skips one byte.
